### PR TITLE
feat!: bundle the `gzip` support inside the core SDK

### DIFF
--- a/analytics/src/main/java/com/rudderstack/sdk/java/analytics/GzipRequestInterceptor.java
+++ b/analytics/src/main/java/com/rudderstack/sdk/java/analytics/GzipRequestInterceptor.java
@@ -1,0 +1,51 @@
+package com.rudderstack.sdk.java.analytics;
+
+import okhttp3.*;
+import okio.BufferedSink;
+import okio.GzipSink;
+import okio.Okio;
+
+import java.io.IOException;
+
+/**
+ * This interceptor compresses the HTTP request body. Copied from
+ * https://github.com/square/okhttp/wiki/Interceptors#rewriting-requests
+ */
+final class GzipRequestInterceptor implements Interceptor {
+  @Override
+  public Response intercept(Chain chain) throws IOException {
+    Request originalRequest = chain.request();
+    if (originalRequest.body() == null || originalRequest.header("Content-Encoding") != null) {
+      return chain.proceed(originalRequest);
+    }
+
+    Request compressedRequest =
+            originalRequest
+                    .newBuilder()
+                    .header("Content-Encoding", "gzip")
+                    .method(originalRequest.method(), gzip(originalRequest.body()))
+                    .build();
+    return chain.proceed(compressedRequest);
+  }
+
+  private RequestBody gzip(final RequestBody body) {
+    return new RequestBody() {
+      @Override
+      public MediaType contentType() {
+        return body.contentType();
+      }
+
+      @Override
+      public long contentLength() {
+        return -1; // We don't know the compressed length in advance!
+      }
+
+      @Override
+      public void writeTo(BufferedSink sink) throws IOException {
+        BufferedSink gzipSink = Okio.buffer(new GzipSink(sink));
+        body.writeTo(gzipSink);
+        gzipSink.close();
+      }
+    };
+  }
+}

--- a/analytics/src/main/java/com/rudderstack/sdk/java/analytics/Platform.java
+++ b/analytics/src/main/java/com/rudderstack/sdk/java/analytics/Platform.java
@@ -21,13 +21,17 @@ class Platform {
     return new Platform();
   }
 
-  OkHttpClient defaultClient() {
-    OkHttpClient client =
+  OkHttpClient defaultClient(boolean enableGZIP) {
+    OkHttpClient.Builder builder =
         new OkHttpClient.Builder()
             .connectTimeout(15, TimeUnit.SECONDS)
             .readTimeout(15, TimeUnit.SECONDS)
-            .writeTimeout(15, TimeUnit.SECONDS)
-            .build();
+            .writeTimeout(15, TimeUnit.SECONDS);
+
+    if (enableGZIP) {
+      builder.addInterceptor(new GzipRequestInterceptor());
+    }
+    OkHttpClient client = builder.build();
     return client;
   }
 

--- a/analytics/src/main/java/com/rudderstack/sdk/java/analytics/RudderAnalytics.java
+++ b/analytics/src/main/java/com/rudderstack/sdk/java/analytics/RudderAnalytics.java
@@ -148,7 +148,7 @@ public class RudderAnalytics {
     private List<Callback> callbacks;
     private int queueCapacity;
     private boolean forceTlsV1 = false;
-    private boolean enableGZIP = true;
+    private boolean gzip = true;
 
     Builder(String writeKey) {
       if (writeKey == null || writeKey.trim().length() == 0) {
@@ -167,8 +167,8 @@ public class RudderAnalytics {
     }
 
     /** Disable the GZIP client. */
-    public Builder enableGZIP(boolean enableGZIP) {
-      this.enableGZIP = enableGZIP;
+    public Builder setGZIP(boolean gzip) {
+      this.gzip = gzip;
       return this;
     }
 
@@ -365,7 +365,7 @@ public class RudderAnalytics {
       }
 
       if (client == null) {
-        client = Platform.get().defaultClient(this.enableGZIP);
+        client = Platform.get().defaultClient(this.gzip);
       }
 
       if (log == null) {

--- a/analytics/src/main/java/com/rudderstack/sdk/java/analytics/RudderAnalytics.java
+++ b/analytics/src/main/java/com/rudderstack/sdk/java/analytics/RudderAnalytics.java
@@ -148,6 +148,7 @@ public class RudderAnalytics {
     private List<Callback> callbacks;
     private int queueCapacity;
     private boolean forceTlsV1 = false;
+    private boolean enableGZIP = true;
 
     Builder(String writeKey) {
       if (writeKey == null || writeKey.trim().length() == 0) {
@@ -162,6 +163,12 @@ public class RudderAnalytics {
         throw new NullPointerException("Null client");
       }
       this.client = client;
+      return this;
+    }
+
+    /** Disable the GZIP client. */
+    public Builder enableGZIP(boolean enableGZIP) {
+      this.enableGZIP = enableGZIP;
       return this;
     }
 
@@ -358,7 +365,7 @@ public class RudderAnalytics {
       }
 
       if (client == null) {
-        client = Platform.get().defaultClient();
+        client = Platform.get().defaultClient(this.enableGZIP);
       }
 
       if (log == null) {


### PR DESCRIPTION
## Description of the change

Now, GZIP will be enabled by default and have also introduced an API to toggle the GZIP default value, called `setGZIP`. If user continues to use the `client` API to pass the OkHttpClient then `setGZIP` API value will not be taken into consideration.

BREAKING CHANGE: Now user who are using the Java SDK, with self-hosted dataPlane and without their own custom `OkHttpClient` (passed using `client` API)` needs to make sure that their server supports GZIP i.e., their server version is above 1.4, else they could either use `setGZIP` API or pass a custom OkHttpClient instance without the GZIP interceptor.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)