### PR TITLE
feat: introduce `setDataPlaneUrl` and mark `endPoint` as deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - [New](https://github.com/rudderlabs/rudder-sdk-java/pull/43) Add CI feature
 - [New](https://github.com/rudderlabs/rudder-sdk-java/pull/41) Add support for channel object in individual payload
 - [New](https://github.com/rudderlabs/rudder-sdk-java/pull/38) Add library info into the context object at each individual message
+- [New](https://github.com/rudderlabs/rudder-sdk-java/pull/45) Introduce setDataPlaneUrl and mark endPoint as deprecated
 - [Breaking change](https://github.com/rudderlabs/rudder-sdk-java/pull/42) Bundle the gzip support inside the core SDK
 
 - [Chore] Dependency upgrades

--- a/analytics-sample/src/main/java/sample/Main.java
+++ b/analytics-sample/src/main/java/sample/Main.java
@@ -17,7 +17,7 @@ public class Main {
     // https://rudder.com/rudder-engineering/sources/test-java/debugger
     final RudderAnalytics analytics =
             RudderAnalytics.builder("write_key")
-                    .endpoint("data_plane_url")
+                    .setDataPlaneUrl("data_plane_url")
                     .plugin(blockingFlush.plugin())
                     .plugin(new LoggingPlugin())
                     .client(createClient())

--- a/analytics/src/main/java/com/rudderstack/sdk/java/analytics/RudderAnalytics.java
+++ b/analytics/src/main/java/com/rudderstack/sdk/java/analytics/RudderAnalytics.java
@@ -189,14 +189,7 @@ public class RudderAnalytics {
      */
     @Deprecated
     public Builder endpoint(String endpoint) {
-      if (endpoint == null || endpoint.trim().length() == 0) {
-        throw new NullPointerException("endpoint cannot be null or empty.");
-      }
-      if (! endpoint.endsWith("/")){
-        endpoint += "/";
-      }
-      this.endpoint = HttpUrl.parse(endpoint + DEFAULT_PATH);
-      return this;
+      return setDataPlaneUrl(endpoint);
     }
 
     /**

--- a/analytics/src/main/java/com/rudderstack/sdk/java/analytics/RudderAnalytics.java
+++ b/analytics/src/main/java/com/rudderstack/sdk/java/analytics/RudderAnalytics.java
@@ -134,7 +134,7 @@ public class RudderAnalytics {
     private final String writeKey;
     private OkHttpClient client;
     private Log log;
-    public HttpUrl endpoint;
+    @Deprecated public HttpUrl endpoint;
     public HttpUrl uploadURL;
     private String userAgent = DEFAULT_USER_AGENT;
     private List<MessageTransformer> messageTransformers;
@@ -184,7 +184,10 @@ public class RudderAnalytics {
     /**
      * Set an endpoint (host only) that this client should upload events to. Uses {@code
      * http://hosted.rudderlabs.com} by default.
+     *
+     * &#064;Deprecated  use {@link #setDataPlaneUrl(String)}
      */
+    @Deprecated
     public Builder endpoint(String endpoint) {
       if (endpoint == null || endpoint.trim().length() == 0) {
         throw new NullPointerException("endpoint cannot be null or empty.");
@@ -193,6 +196,20 @@ public class RudderAnalytics {
         endpoint += "/";
       }
       this.endpoint = HttpUrl.parse(endpoint + DEFAULT_PATH);
+      return this;
+    }
+
+    /**
+     * Set a dataPlaneUrl that this client should upload events to.
+     */
+    public Builder setDataPlaneUrl(String dataPlaneUrl) {
+      if (dataPlaneUrl == null || dataPlaneUrl.trim().length() == 0) {
+        throw new NullPointerException("dataPlaneUrl cannot be null or empty.");
+      }
+      if (! dataPlaneUrl.endsWith("/")){
+        dataPlaneUrl += "/";
+      }
+      this.endpoint = HttpUrl.parse(dataPlaneUrl + DEFAULT_PATH);
       return this;
     }
 

--- a/analytics/src/test/java/com/rudderstack/sdk/java/analytics/RudderAnalyticsBuilderTest.java
+++ b/analytics/src/test/java/com/rudderstack/sdk/java/analytics/RudderAnalyticsBuilderTest.java
@@ -265,14 +265,44 @@ public class RudderAnalyticsBuilderTest {
   }
 
   @Test
+  public void emptyDataPlaneUrl() {
+    try {
+      builder.setDataPlaneUrl("");
+      fail("Should fail for empty dataPlaneUrl");
+    } catch (NullPointerException e) {
+      assertThat(e).hasMessage("dataPlaneUrl cannot be null or empty.");
+    }
+
+    try {
+      builder.setDataPlaneUrl("  ");
+      fail("Should fail for empty dataPlaneUrl");
+    } catch (NullPointerException e) {
+      assertThat(e).hasMessage("dataPlaneUrl cannot be null or empty.");
+    }
+  }
+
+  @Test
   public void buildsWithValidEndpoint() {
     RudderAnalytics analytics = builder.endpoint("https://hosted.rudderlabs.com").build();
     assertThat(analytics).isNotNull();
   }
 
   @Test
+  public void buildsWithValidDataPlaneUrl() {
+    RudderAnalytics analytics = builder.setDataPlaneUrl("https://hosted.rudderlabs.com").build();
+    assertThat(analytics).isNotNull();
+  }
+
+  @Test
   public void buildsCorrectEndpoint() {
     builder.endpoint("https://hosted.rudderlabs.com");
+    String expectedURL = "https://hosted.rudderlabs.com/v1/batch";
+    assertEquals(expectedURL, builder.endpoint.toString());
+  }
+
+  @Test
+  public void buildsCorrectDataPlaneUrl() {
+    builder.setDataPlaneUrl("https://hosted.rudderlabs.com");
     String expectedURL = "https://hosted.rudderlabs.com/v1/batch";
     assertEquals(expectedURL, builder.endpoint.toString());
   }

--- a/analytics/src/test/java/com/rudderstack/sdk/java/analytics/RudderAnalyticsBuilderTest.java
+++ b/analytics/src/test/java/com/rudderstack/sdk/java/analytics/RudderAnalyticsBuilderTest.java
@@ -243,7 +243,7 @@ public class RudderAnalyticsBuilderTest {
       builder.endpoint(null);
       fail("Should fail for null endpoint");
     } catch (NullPointerException e) {
-      assertThat(e).hasMessage("endpoint cannot be null or empty.");
+      assertThat(e).hasMessage("dataPlaneUrl cannot be null or empty.");
     }
   }
 
@@ -253,14 +253,14 @@ public class RudderAnalyticsBuilderTest {
       builder.endpoint("");
       fail("Should fail for empty endpoint");
     } catch (NullPointerException e) {
-      assertThat(e).hasMessage("endpoint cannot be null or empty.");
+      assertThat(e).hasMessage("dataPlaneUrl cannot be null or empty.");
     }
 
     try {
       builder.endpoint("  ");
       fail("Should fail for empty endpoint");
     } catch (NullPointerException e) {
-      assertThat(e).hasMessage("endpoint cannot be null or empty.");
+      assertThat(e).hasMessage("dataPlaneUrl cannot be null or empty.");
     }
   }
 


### PR DESCRIPTION
## Description of the change

To have uniform behaviour across SDKs, we've decided to mark `endPoint` API as deprecated and replace it with `setDataPlaneUrl` API. In future versions, we'll remove endPoint API.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
