### PR TITLE
chore: add DeepWiki badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build & Code Quality Checks](https://github.com/rudderlabs/rudder-sdk-java/actions/workflows/build-and-quality-checks.yml/badge.svg?branch=ci%2FaddCIFeatures)](https://github.com/rudderlabs/rudder-sdk-java/actions/workflows/build-and-quality-checks.yml)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/rudderlabs/rudder-sdk-java)
 
 # What is RudderStack?
 


### PR DESCRIPTION
## Summary

Add a DeepWiki badge to the README, placed alongside the existing CI badge at the top of the file. The badge links to the DeepWiki page for this repository (`https://deepwiki.com/rudderlabs/rudder-sdk-java`), providing quick access to AI-generated documentation and codebase exploration.

## Changes

- Added `[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/rudderlabs/rudder-sdk-java)` badge to `README.md`

## Test plan

- [ ] Verify the badge renders correctly on the GitHub README
- [ ] Verify the badge link navigates to the correct DeepWiki page
