### PR TITLE
chore(codeowners): set sdk_team as code owners

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 title: "BUG : <Title>"
 labels: bug, open source
-assignees: itsdebs
+assignees: []
 ---
 
 **Describe the bug**

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @rudderlabs/sdk_team


### PR DESCRIPTION
## Summary

Adds a root `CODEOWNERS` with `* @rudderlabs/sdk_team` so chore PRs (Dependabot merges, CI fixes) auto-request review from the whole SDK team and any member's approval unblocks them. No CODEOWNERS existed before. Brings this repo in line with the other SDK repos already migrated.

## Changes

- `CODEOWNERS` (new): `* @rudderlabs/sdk_team`
- `.github/ISSUE_TEMPLATE/bug_report.md`: clears the hardcoded individual assignee (`itsdebs` → `[]`), matching the pattern used in the other SDK repos

## Testing

Config-only change — verify on the next chore PR that review is auto-requested from `sdk_team` (the open Dependabot PRs #128 and #141 can serve as the verification case once this merges). New bug reports should open unassigned.

## Screenshots

No UI changes in this PR.

## Notes

Fixes [SDK-5173](https://linear.app/rudderstack/issue/SDK-5173/set-sdk-team-as-code-owners-in-rudder-sdk-java). No breaking changes or migration steps required.
