### PR TITLE
fix: sdk-5293 preserve java sdk delivery semantics

### DIFF
--- a/analytics-sample/src/main/java/sample/BlockingFlush.java
+++ b/analytics-sample/src/main/java/sample/BlockingFlush.java
@@ -50,12 +50,12 @@ public class BlockingFlush {
           new Callback() {
             @Override
             public void success(Message message) {
-              phaser.arrive();
+              phaser.arriveAndDeregister();
             }
 
             @Override
             public void failure(Message message, Throwable throwable) {
-              phaser.arrive();
+              phaser.arriveAndDeregister();
             }
           });
     };

--- a/analytics/src/main/java/com/rudderstack/sdk/java/analytics/internal/AnalyticsClient.java
+++ b/analytics/src/main/java/com/rudderstack/sdk/java/analytics/internal/AnalyticsClient.java
@@ -17,6 +17,9 @@ import com.segment.backo.Backo;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -26,6 +29,7 @@ import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
@@ -42,6 +46,7 @@ public class AnalyticsClient {
   private static final int MSG_MAX_SIZE = 1024 * 32;
   private static final Charset ENCODING = StandardCharsets.UTF_8;
   private static Gson gsonInstance;
+  private static final int LOOPER_COMPLETION_TIMEOUT_SECONDS = 5;
 
   static {
     Map<String, String> library = new LinkedHashMap<>();
@@ -65,6 +70,7 @@ public class AnalyticsClient {
   private final ExecutorService looperExecutor;
   private final ScheduledExecutorService flushScheduler;
   private final AtomicBoolean isShutDown;
+  private volatile Future<?> looperFuture;
 
   public static AnalyticsClient create(
       HttpUrl uploadUrl,
@@ -120,7 +126,7 @@ public class AnalyticsClient {
 
     this.currentQueueSizeInBytes = 0;
 
-    if (!isShutDown.get()) looperExecutor.submit(new Looper());
+    if (!isShutDown.get()) looperFuture = looperExecutor.submit(new Looper());
 
     flushScheduler = Executors.newScheduledThreadPool(1, threadFactory);
     flushScheduler.scheduleAtFixedRate(
@@ -225,11 +231,27 @@ public class AnalyticsClient {
       // we can shutdown the flush scheduler without worrying
       flushScheduler.shutdownNow();
 
+      waitForLooperCompletion();
       shutdownAndWait(looperExecutor, "looper");
       shutdownAndWait(networkExecutor, "network");
 
       log.print(
           VERBOSE, "Analytics client shut down in %s ms", (System.currentTimeMillis() - start));
+    }
+  }
+
+  private void waitForLooperCompletion() {
+    if (looperFuture == null) return;
+
+    try {
+      looperFuture.get(LOOPER_COMPLETION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    } catch (InterruptedException exception) {
+      log.print(ERROR, exception, "Interrupted while waiting for looper to complete.");
+      Thread.currentThread().interrupt();
+      if (!looperFuture.isDone()) looperFuture.cancel(true);
+    } catch (Exception exception) {
+      log.print(ERROR, exception, "Error waiting for looper to complete.");
+      if (!looperFuture.isDone()) looperFuture.cancel(true);
     }
   }
 
@@ -329,6 +351,7 @@ public class AnalyticsClient {
   }
 
   static class BatchUploadTask implements Runnable {
+    private static final long MAX_RETRY_AFTER_MILLIS = TimeUnit.MINUTES.toMillis(5);
     private static final Backo BACKO =
         Backo.builder() //
             .base(TimeUnit.SECONDS, 15) //
@@ -340,6 +363,7 @@ public class AnalyticsClient {
     private final Backo backo;
     final Batch batch;
     private final int maxRetries;
+    private long retryAfterMillis;
 
     static BatchUploadTask create(AnalyticsClient client, Batch batch, int maxRetries) {
       return new BatchUploadTask(client, BACKO, batch, maxRetries);
@@ -362,6 +386,7 @@ public class AnalyticsClient {
 
     /** Returns {@code true} to indicate a batch should be retried. {@code false} otherwise. */
     boolean upload() {
+      retryAfterMillis = 0;
       client.log.print(VERBOSE, "Uploading batch %s.", batch.sequence());
 
       try {
@@ -382,10 +407,16 @@ public class AnalyticsClient {
 
         int status = response.code();
         if (is5xx(status)) {
+          retryAfterMillis =
+              parseRetryAfterMillis(
+                  response.headers().get("Retry-After"), System.currentTimeMillis());
           client.log.print(
               DEBUG, "Could not upload batch %s due to server error. Retrying.", batch.sequence());
           return true;
         } else if (status == 429) {
+          retryAfterMillis =
+              parseRetryAfterMillis(
+                  response.headers().get("Retry-After"), System.currentTimeMillis());
           client.log.print(
               DEBUG, "Could not upload batch %s due to rate limiting. Retrying.", batch.sequence());
           return true;
@@ -416,7 +447,11 @@ public class AnalyticsClient {
         boolean retry = upload();
         if (!retry) return;
         try {
-          backo.sleep(attempt);
+          if (retryAfterMillis > 0) {
+            Thread.sleep(retryAfterMillis);
+          } else {
+            backo.sleep(attempt);
+          }
         } catch (InterruptedException e) {
           client.log.print(
               DEBUG, "Thread interrupted while backing off for batch %s.", batch.sequence());
@@ -431,6 +466,26 @@ public class AnalyticsClient {
 
     private static boolean is5xx(int status) {
       return status >= 500 && status < 600;
+    }
+
+    static long parseRetryAfterMillis(String value, long nowMillis) {
+      if (value == null || value.trim().isEmpty()) return 0;
+
+      try {
+        long seconds = Long.parseLong(value.trim());
+        if (seconds <= 0) return 0;
+        return Math.min(TimeUnit.SECONDS.toMillis(seconds), MAX_RETRY_AFTER_MILLIS);
+      } catch (NumberFormatException ignored) {
+        try {
+          long retryAtMillis =
+              ZonedDateTime.parse(value.trim(), DateTimeFormatter.RFC_1123_DATE_TIME)
+                  .toInstant()
+                  .toEpochMilli();
+          return Math.min(Math.max(retryAtMillis - nowMillis, 0), MAX_RETRY_AFTER_MILLIS);
+        } catch (DateTimeParseException invalidDate) {
+          return 0;
+        }
+      }
     }
   }
 

--- a/analytics/src/test/java/com/rudderstack/sdk/java/analytics/internal/RudderAnalyticsClientTest.java
+++ b/analytics/src/test/java/com/rudderstack/sdk/java/analytics/internal/RudderAnalyticsClientTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
@@ -28,6 +29,9 @@ import com.segment.backo.Backo;
 import com.squareup.burst.BurstJUnit4;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -45,6 +49,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.*;
+import org.mockito.InOrder;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import retrofit2.Call;
@@ -420,6 +425,34 @@ public class RudderAnalyticsClientTest {
   }
 
   @Test
+  public void parsesRetryAfterSecondsAndCapsLargeValues() {
+    assertThat(BatchUploadTask.parseRetryAfterMillis("2", 0)).isEqualTo(2000);
+    assertThat(BatchUploadTask.parseRetryAfterMillis("9999", 0))
+        .isEqualTo(TimeUnit.MINUTES.toMillis(5));
+  }
+
+  @Test
+  public void parsesRetryAfterHttpDate() {
+    long now = Instant.parse("2026-08-17T10:00:00Z").toEpochMilli();
+    String retryAfter =
+        DateTimeFormatter.RFC_1123_DATE_TIME
+            .format(Instant.ofEpochMilli(now + 3000).atZone(ZoneOffset.UTC));
+
+    assertThat(BatchUploadTask.parseRetryAfterMillis(retryAfter, now)).isEqualTo(3000);
+  }
+
+  @Test
+  public void ignoresInvalidOrExpiredRetryAfterValues() {
+    long now = Instant.parse("2026-08-17T10:00:00Z").toEpochMilli();
+    String expired =
+        DateTimeFormatter.RFC_1123_DATE_TIME
+            .format(Instant.ofEpochMilli(now - 1000).atZone(ZoneOffset.UTC));
+
+    assertThat(BatchUploadTask.parseRetryAfterMillis("invalid", now)).isZero();
+    assertThat(BatchUploadTask.parseRetryAfterMillis(expired, now)).isZero();
+  }
+
+  @Test
   public void batchDoesNotRetryForNon5xxAndNon429HTTPErrors() {
     AnalyticsClient client = newClient();
     TrackMessage trackMessage = TrackMessage.builder("foo").userId("bar").build();
@@ -607,6 +640,10 @@ public class RudderAnalyticsClientTest {
     verify(networkExecutor).shutdown();
     verify(networkExecutor).awaitTermination(1, TimeUnit.SECONDS);
     verify(networkExecutor).submit(any(AnalyticsClient.BatchUploadTask.class));
+
+    InOrder shutdownOrder = inOrder(networkExecutor);
+    shutdownOrder.verify(networkExecutor).submit(any(AnalyticsClient.BatchUploadTask.class));
+    shutdownOrder.verify(networkExecutor).shutdown();
   }
 
   @Test


### PR DESCRIPTION
## What changed

- wait for the message looper to submit final batches before shutting down the network executor
- honor numeric and HTTP-date `Retry-After` values for retryable responses, capped at five minutes
- deregister completed BlockingFlush parties
- add shutdown ordering and Retry-After regression tests

## Why

Shutdown could race with final batch submission. Retryable responses ignored server delay guidance. The BlockingFlush sample retained completed Phaser parties.

This adapts the applicable behavior from upstream commits `82dfde2`, `07802a3`, and `6a29b4a`. It excludes unrelated authentication, queue API, release, and E2E infrastructure changes.

## Validation

- `mvn -q -pl analytics,analytics-sample -am test` passed
- `git diff --check` passed
- the repository-wide Spotless check has pre-existing violations in unchanged analytics-core files

## References

- [SDK-5293](https://linear.app/rudderstack/issue/SDK-5293/improve-java-sdk-shutdown-and-retry-behavior)
- [audit and merge plan](https://app.notion.com/p/3bff2b415dd081bcb7f2c0018f144a84)