### PR TITLE
fix: sdk-4992 migrate maven publishing to central portal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,11 +21,11 @@
     <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
         </snapshotRepository>
         <repository>
             <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <url>https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
 
@@ -333,7 +333,7 @@
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>
-                    <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
+                    <nexusUrl>https://ossrh-staging-api.central.sonatype.com/</nexusUrl>
                     <!--<autoVersionSubmodules>true</autoVersionSubmodules>
                     <checkModificationExcludes>
                         <checkModificationExclude>pom.xml</checkModificationExclude>


### PR DESCRIPTION
## Summary

- replace retired OSSRH release endpoint with the Central Portal compatibility endpoint
- replace retired OSSRH snapshot endpoint with the Central snapshot repository
- configure the Nexus staging plugin to use the Central Portal compatibility service

## Verification

- `mvn -B clean verify`
- `mvn -B clean verify -Psonatype-oss-release` with the approved signing key
- 326 tests passed
- 14 generated artifact signatures verified
- effective POM contains no `s01.oss.sonatype.org` references

## Release impact

This `fix:` commit should make Release Please propose version `3.1.4`.

Linear: https://linear.app/rudderstack/issue/SDK-4992/migrate-rudder-sdk-java-to-release-please