### PR TITLE
ci: sdk-5334 notify slack of github releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,6 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -37,9 +40,59 @@ jobs:
       # last release. Merging that PR bumps the version, updates the changelog,
       # creates the git tag and the GitHub release.
       - name: Run release-please
+        id: release
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           token: ${{ steps.generate-token.outputs.token }}
           target-branch: master
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  notify-slack:
+    name: Notify Slack channel
+    needs: [release-please]
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      RELEASE_URL: https://github.com/${{ github.repository }}/releases/tag/${{ needs.release-please.outputs.tag_name }}
+      TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Notify Slack channel
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
+        continue-on-error: true
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          errors: true
+          retries: rapid
+          payload: |
+            {
+              "channel": "${{ secrets.SLACK_RELEASE_CHANNEL_ID }}",
+              "text": "*<${{ env.RELEASE_URL }}|${{ env.TAG_NAME }}>*\nCC: <!subteam^S03SW7DM8P3>",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": ":tada:  Java SDK - New GitHub Release  :tada:"
+                  }
+                },
+                {
+                  "type": "divider"
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*<${{ env.RELEASE_URL }}|${{ env.TAG_NAME }}>*\nCC: <!subteam^S03SW7DM8P3>"
+                  }
+                }
+              ]
+            }


### PR DESCRIPTION
## Summary

- expose the Release Please `release_created` and `tag_name` outputs
- notify `#releases` only after Release Please creates a GitHub release
- link the exact tag and mention the SDK team
- keep Slack failures non-blocking

## Validation

- `actionlint .github/workflows/release-please.yml`
- parsed the workflow YAML and embedded Slack JSON payload
- `git diff --check`

## Operational note

The job uses the standard organization secrets `SLACK_BOT_TOKEN` and `SLACK_RELEASE_CHANNEL_ID`. A repository or organization administrator must confirm that `rudder-sdk-java` is included in the organization secret allowlist. My account cannot inspect that allowlist.

The message says “New GitHub Release.” It does not claim that the separate Maven Central publication has completed.

Linear: https://linear.app/rudderstack/issue/SDK-5334/notify-releases-when-the-java-sdk-creates-a-github-release