### PR TITLE
ci: sdk-5337 automate maven central publishing

### DIFF
--- a/.github/workflows/build-and-quality-checks.yml
+++ b/.github/workflows/build-and-quality-checks.yml
@@ -29,9 +29,7 @@ jobs:
           distribution: 'zulu' # Alternative distribution options are available.
 
       - name: Set up Maven
-        uses: stCarolas/setup-maven@07fbbe97d97ef44336b7382563d66743297e442f # v4.5
-        with:
-          maven-version: 3.8.6
+        run: mvn --version
 
       - name: Cache local Maven repository
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/build-and-quality-checks.yml
+++ b/.github/workflows/build-and-quality-checks.yml
@@ -100,8 +100,14 @@ jobs:
             analytics-core/target/site
             analytics/target/site
 
+      - name: Set up JDK 21 for Sonar analysis
+        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1
+        with:
+          java-version: 21
+          distribution: 'zulu'
+
       - name: Sonar analysis
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=rudderlabs_rudder-sdk-java
+        run: mvn -B org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=rudderlabs_rudder-sdk-java

--- a/.github/workflows/build-and-quality-checks.yml
+++ b/.github/workflows/build-and-quality-checks.yml
@@ -53,6 +53,11 @@ jobs:
       - name: Unit Test and Build
         run: mvn clean install
 
+      - name: Verify published POMs
+        run: |
+          version="$(mvn --batch-mode --quiet --no-transfer-progress help:evaluate -Dexpression=revision -DforceStdout)"
+          scripts/verify-published-poms.sh "$version"
+
 #      - name: Jacoco Badge generator
 #        uses: cicirello/jacoco-badge-generator@v2
 #        with:

--- a/.github/workflows/build-and-quality-checks.yml
+++ b/.github/workflows/build-and-quality-checks.yml
@@ -34,7 +34,7 @@ jobs:
           maven-version: 3.8.6
 
       - name: Cache local Maven repository
-        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -42,7 +42,7 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Cache SonarCloud packages
-        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
@@ -72,7 +72,7 @@ jobs:
 #          add: '*.svg'
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3.2.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: Coverage report
           path: |
@@ -84,7 +84,7 @@ jobs:
           mvn pmd:cpd
 
       - name: Upload PMD lint report
-        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3.2.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: PMD lint report
           path: |
@@ -95,7 +95,7 @@ jobs:
         run: mvn checkstyle:checkstyle
 
       - name: Upload Checklist lint report
-        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3.2.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: Checklist lint report
           path: |

--- a/.github/workflows/publish-maven-central.yml
+++ b/.github/workflows/publish-maven-central.yml
@@ -41,9 +41,7 @@ jobs:
           server-password: NEXUS_PASSWORD
 
       - name: Set up Maven
-        uses: stCarolas/setup-maven@07fbbe97d97ef44336b7382563d66743297e442f # v4.5
-        with:
-          maven-version: 3.9.11
+        run: mvn --version
 
       - name: Verify the release tag and version
         id: release

--- a/.github/workflows/publish-maven-central.yml
+++ b/.github/workflows/publish-maven-central.yml
@@ -1,0 +1,219 @@
+name: Publish to Maven Central
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: maven-central-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Build, sign, publish, and verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    environment: maven-central
+    outputs:
+      version: ${{ steps.release.outputs.version }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout the exact release tag
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
+
+      - name: Set up JDK 17 and Maven Central credentials
+        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1
+        with:
+          java-version: 17
+          distribution: zulu
+          cache: maven
+          server-id: central
+          server-username: NEXUS_USERNAME
+          server-password: NEXUS_PASSWORD
+
+      - name: Set up Maven
+        uses: stCarolas/setup-maven@07fbbe97d97ef44336b7382563d66743297e442f # v4.5
+        with:
+          maven-version: 3.9.11
+
+      - name: Verify the release tag and version
+        id: release
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid release tag: $TAG_NAME" >&2
+            exit 1
+          fi
+
+          git tag --points-at HEAD | grep -Fx "$TAG_NAME"
+          git merge-base --is-ancestor HEAD origin/master
+
+          version="${TAG_NAME#v}"
+          pom_version="$(mvn --batch-mode --quiet --no-transfer-progress \
+            help:evaluate -Dexpression=revision -DforceStdout)"
+
+          if [[ "$pom_version" != "$version" ]]; then
+            echo "Tag $TAG_NAME does not match POM revision $pom_version" >&2
+            exit 1
+          fi
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "RELEASE_VERSION=$version" >> "$GITHUB_ENV"
+
+      - name: Check whether the version is already public
+        id: publication
+        run: |
+          set -euo pipefail
+
+          pom_url="https://repo1.maven.org/maven2/com/rudderstack/sdk/java/analytics/analytics/${RELEASE_VERSION}/analytics-${RELEASE_VERSION}.pom"
+
+          if curl --fail --silent --head "$pom_url" >/dev/null; then
+            echo "already-published=true" >> "$GITHUB_OUTPUT"
+            echo "Version ${RELEASE_VERSION} is already public. The workflow will verify it without publishing again."
+          else
+            echo "already-published=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Validate publishing secrets and import the signing key
+        if: ${{ steps.publication.outputs.already-published != 'true' }}
+        env:
+          NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+          SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
+          SIGNING_PRIVATE_KEY_BASE64: ${{ secrets.SIGNING_PRIVATE_KEY_BASE64 }}
+        run: |
+          set -euo pipefail
+
+          for name in NEXUS_USERNAME NEXUS_PASSWORD SIGNING_KEY_ID SIGNING_PRIVATE_KEY_BASE64; do
+            if [[ -z "${!name:-}" ]]; then
+              echo "Missing required maven-central Environment secret: $name" >&2
+              exit 1
+            fi
+          done
+
+          gnupg_home="$RUNNER_TEMP/gnupg"
+          mkdir -m 700 "$gnupg_home"
+          echo "GNUPGHOME=$gnupg_home" >> "$GITHUB_ENV"
+          echo "GPG_KEY_ID=$SIGNING_KEY_ID" >> "$GITHUB_ENV"
+
+          printf '%s' "$SIGNING_PRIVATE_KEY_BASE64" | base64 --decode | \
+            GNUPGHOME="$gnupg_home" gpg --batch --import
+          GNUPGHOME="$gnupg_home" gpg --batch --list-secret-keys "$SIGNING_KEY_ID"
+
+      - name: Build, test, sign, and validate release artifacts
+        if: ${{ steps.publication.outputs.already-published != 'true' }}
+        run: |
+          set -euo pipefail
+          mvn --batch-mode --no-transfer-progress \
+            -Prelease \
+            -Dgpg.keyname="$GPG_KEY_ID" \
+            clean verify
+          scripts/verify-release-artifacts.sh "$RELEASE_VERSION"
+
+      - name: Publish and wait for Maven Central
+        if: ${{ steps.publication.outputs.already-published != 'true' }}
+        env:
+          NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+        run: |
+          set -euo pipefail
+          mvn --batch-mode --no-transfer-progress \
+            -Prelease \
+            -DskipTests \
+            -Dgpg.keyname="$GPG_KEY_ID" \
+            -Dcentral.autoPublish=true \
+            -Dcentral.waitUntil=published \
+            deploy
+
+      - name: Verify the public Maven Central release
+        run: scripts/verify-maven-central-release.sh "$RELEASE_VERSION"
+
+  notify-success:
+    name: Notify successful Maven Central publication
+    needs: [publish]
+    if: ${{ needs.publish.result == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      RELEASE_URL: https://github.com/${{ github.repository }}/releases/tag/${{ github.event.release.tag_name }}
+      CENTRAL_URL: https://central.sonatype.com/artifact/com.rudderstack.sdk.java.analytics/analytics/${{ needs.publish.outputs.version }}
+      TAG_NAME: ${{ github.event.release.tag_name }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Notify Slack channel
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
+        continue-on-error: true
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          errors: true
+          retries: rapid
+          payload: |
+            {
+              "channel": "${{ secrets.SLACK_RELEASE_CHANNEL_ID }}",
+              "text": "Java SDK ${{ env.TAG_NAME }} is available on Maven Central: ${{ env.CENTRAL_URL }}",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": ":package: Java SDK published to Maven Central"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*<${{ env.RELEASE_URL }}|${{ env.TAG_NAME }}>* is now available on *<${{ env.CENTRAL_URL }}|Maven Central>*\nCC: <!subteam^S03SW7DM8P3>"
+                  }
+                }
+              ]
+            }
+
+  notify-failure:
+    name: Notify failed Maven Central publication
+    needs: [publish]
+    if: ${{ always() && needs.publish.result == 'failure' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      TAG_NAME: ${{ github.event.release.tag_name }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Notify Slack channel
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
+        continue-on-error: true
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          errors: true
+          retries: rapid
+          payload: |
+            {
+              "channel": "${{ secrets.SLACK_RELEASE_CHANNEL_ID }}",
+              "text": "Java SDK ${{ env.TAG_NAME }} failed to publish to Maven Central: ${{ env.RUN_URL }}"
+            }

--- a/.github/workflows/publish-maven-central.yml
+++ b/.github/workflows/publish-maven-central.yml
@@ -36,7 +36,6 @@ jobs:
         with:
           java-version: 17
           distribution: zulu
-          cache: maven
           server-id: central
           server-username: NEXUS_USERNAME
           server-password: NEXUS_PASSWORD

--- a/.github/workflows/publish-maven-central.yml
+++ b/.github/workflows/publish-maven-central.yml
@@ -4,9 +4,6 @@ on:
   release:
     types: [published]
 
-permissions:
-  contents: read
-
 concurrency:
   group: maven-central-${{ github.event.release.tag_name }}
   cancel-in-progress: false
@@ -17,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     environment: maven-central
+    permissions:
+      contents: read
     outputs:
       version: ${{ steps.release.outputs.version }}
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ pom.xml.releaseBackup
 pom.xml.versionsBackup
 pom.xml.next
 release.properties
+.flattened-pom.xml
 .vscode
 
 **/bin

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ Map<String, Object> map=new HashMap<>();
 For more information on the different types of events supported by the Java SDK, refer to
 our [docs](https://www.rudderstack.com/docs/sources/event-streams/sdks/rudderstack-java-sdk/).
 
+## Maintainer documentation
+
+See the [Java SDK release process](docs/RELEASING.md) for versioning, Maven Central publication, verification, and recovery.
+
 ## Contact Us
 
 If you come across any issues while configuring or using this SDK, feel free to start a conversation on

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,69 @@
+# Java SDK release process
+
+The Java SDK uses Release Please and GitHub Actions. A release requires no local Maven publication commands.
+
+## Prerequisites
+
+The repository must have a GitHub Environment named `maven-central`.
+
+The Environment must:
+
+- Permit only tags matching `v*`.
+- Store `NEXUS_USERNAME` and `NEXUS_PASSWORD` as a Central Portal user token.
+- Store `SIGNING_KEY_ID` and `SIGNING_PRIVATE_KEY_BASE64` for the organization OpenPGP key.
+
+The Central Portal token must have permission to publish the `com.rudderstack.sdk.java.analytics` namespace.
+
+## Create a release
+
+1. Review the open Release Please pull request.
+2. Confirm that its version, changelog, and `pom.xml` revision are correct.
+3. Confirm that all required pull request checks pass.
+4. Merge the Release Please pull request.
+
+Release Please creates the version tag and GitHub release. The published GitHub release triggers [Publish to Maven Central](../.github/workflows/publish-maven-central.yml).
+
+The Maven Central workflow then:
+
+1. Checks out the exact release tag.
+2. Verifies that the tag matches the POM revision and belongs to `master`.
+3. Stops duplicate publication when the version already exists.
+4. Imports the OpenPGP key from the protected Environment.
+5. Runs all tests.
+6. Creates concrete consumer POMs, sources, Javadocs, and signatures.
+7. Validates every release artifact and signature.
+8. Uploads through Sonatype's Central Publishing Maven Plugin.
+9. Waits until Central reports `PUBLISHED`.
+10. Resolves the public SDK and its dependencies from a clean Maven cache.
+11. Sends the final Maven Central result to the release Slack channel.
+
+## Verify a release
+
+The workflow must finish successfully before the release is complete.
+
+Confirm the public artifact at:
+
+```text
+https://central.sonatype.com/artifact/com.rudderstack.sdk.java.analytics/analytics/<version>
+```
+
+The public POM project and parent version elements must contain concrete versions. They must not contain a literal `${revision}` value.
+
+## Recover from a failure
+
+- If publication did not start, fix the workflow or build and rerun the failed job.
+- If Central rejected the deployment, inspect the validation errors before retrying.
+- If Central published the version but public verification failed, rerun the workflow. The workflow skips duplicate publication and repeats public verification.
+- Never move or recreate a published version tag.
+- Never attempt to replace a published Maven Central version. Publish a new patch version instead.
+
+## Rotate credentials
+
+Update credentials only in the `maven-central` GitHub Environment. Do not place credential values in source files, workflow logs, pull requests, or Slack.
+
+After rotation, verify that:
+
+- The Central token still has access to the Java namespace.
+- The private key matches `SIGNING_KEY_ID`.
+- The private key can sign without interactive input.
+- The public key remains available to Maven Central signature validation.

--- a/pom.xml
+++ b/pom.xml
@@ -298,7 +298,7 @@
                 <plugin>
                     <groupId>org.sonarsource.scanner.maven</groupId>
                     <artifactId>sonar-maven-plugin</artifactId>
-                    <version>3.7.0.1746</version>
+                    <version>5.7.0.6970</version>
                 </plugin>
                 <!--Lint check-->
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -5,28 +5,18 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.sonatype.oss</groupId>
-        <artifactId>oss-parent</artifactId>
-        <version>7</version>
-    </parent>
-
     <groupId>com.rudderstack.sdk.java.analytics</groupId>
     <artifactId>analytics-parent</artifactId>
     <version>${revision}</version>
     <packaging>pom</packaging>
     <name>Analytics for Java (Parent)</name>
-    <description>The hassle-free way to add analytics to your Android app.</description>
+    <description>The hassle-free way to add analytics to your Java application.</description>
     <url>https://github.com/rudderlabs/rudder-sdk-java</url>
     <distributionManagement>
         <snapshotRepository>
-            <id>ossrh</id>
+            <id>central</id>
             <url>https://central.sonatype.com/repository/maven-snapshots/</url>
         </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/</url>
-        </repository>
     </distributionManagement>
 
     <modules>
@@ -51,6 +41,8 @@
         <backo.version>1.0.0</backo.version>
         <spring.boot.version>2.7.12</spring.boot.version>
         <docopt.version>0.6.0.20150202</docopt.version>
+        <central.autoPublish>false</central.autoPublish>
+        <central.waitUntil>validated</central.waitUntil>
 
         <!-- Test Dependencies -->
         <junit.version>4.13.2</junit.version>
@@ -118,6 +110,16 @@
             <url>http://opensource.org/licenses/MIT</url>
         </license>
     </licenses>
+
+    <developers>
+        <developer>
+            <id>rudderstack</id>
+            <name>RudderStack</name>
+            <email>contact@rudderstack.com</email>
+            <organization>RudderStack</organization>
+            <organizationUrl>https://www.rudderstack.com</organizationUrl>
+        </developer>
+    </developers>
 
     <dependencyManagement>
         <dependencies>
@@ -327,30 +329,29 @@
 
         <plugins>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.13</version>
-                <extensions>true</extensions>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.8.0</version>
                 <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://ossrh-staging-api.central.sonatype.com/</nexusUrl>
-                    <!--<autoVersionSubmodules>true</autoVersionSubmodules>
-                    <checkModificationExcludes>
-                        <checkModificationExclude>pom.xml</checkModificationExclude>
-                    </checkModificationExcludes>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>-->
+                    <flattenMode>resolveCiFriendliesOnly</flattenMode>
+                    <updatePomFile>true</updatePomFile>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>3.0.1</version>
-                <configuration>
-                    <autoVersionSubmodules>true</autoVersionSubmodules>
-                    <useReleaseProfile>false</useReleaseProfile>
-                    <releaseProfiles>release</releaseProfiles>
-                    <goals>deploy</goals>
-                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>flatten-clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
@@ -403,4 +404,71 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.11.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>${central.autoPublish}</autoPublish>
+                            <waitUntil>${central.waitUntil}</waitUntil>
+                            <waitMaxTime>3600</waitMaxTime>
+                            <checksums>all</checksums>
+                            <deploymentName>rudder-sdk-java-${revision}</deploymentName>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>3.4.0</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>3.12.0</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>3.2.8</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                                <configuration>
+                                    <bestPractices>true</bestPractices>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/scripts/verify-maven-central-release.sh
+++ b/scripts/verify-maven-central-release.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+version="${1:?usage: verify-maven-central-release.sh <version>}"
+
+if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Invalid release version: $version" >&2
+  exit 1
+fi
+
+group_path="com/rudderstack/sdk/java/analytics"
+central_url="https://repo1.maven.org/maven2"
+verification_directory="$(mktemp -d)"
+local_repository="$(mktemp -d)"
+trap 'rm -rf "$verification_directory" "$local_repository"' EXIT
+
+artifacts=(analytics-parent analytics-core analytics analytics-sample)
+
+for attempt in $(seq 1 45); do
+  available=true
+
+  for artifact in "${artifacts[@]}"; do
+    pom_url="${central_url}/${group_path}/${artifact}/${version}/${artifact}-${version}.pom"
+
+    if ! curl --fail --silent --show-error --location \
+      --output "${verification_directory}/${artifact}.pom" "$pom_url"; then
+      available=false
+      break
+    fi
+  done
+
+  if [[ "$available" == true ]]; then
+    break
+  fi
+
+  if [[ "$attempt" == 45 ]]; then
+    echo "Release ${version} did not become available on Maven Central." >&2
+    exit 1
+  fi
+
+  echo "Waiting for Maven Central propagation (${attempt}/45)..."
+  sleep 20
+done
+
+for artifact in "${artifacts[@]}"; do
+  pom="${verification_directory}/${artifact}.pom"
+
+  if grep -Eq '<version>[[:space:]]*\$\{revision\}[[:space:]]*</version>' "$pom"; then
+    echo "Published POM contains an unresolved project or parent version: $artifact" >&2
+    exit 1
+  fi
+
+  grep -Fq "<version>${version}</version>" "$pom"
+done
+
+analytics_jar="${verification_directory}/analytics-${version}.jar"
+curl --fail --silent --show-error --location \
+  --output "$analytics_jar" \
+  "${central_url}/${group_path}/analytics/${version}/analytics-${version}.jar"
+jar tf "$analytics_jar" | grep -Fq 'com/rudderstack/sdk/java/analytics/RudderAnalytics.class'
+
+mvn --batch-mode --quiet --no-transfer-progress \
+  -Dmaven.repo.local="$local_repository" \
+  -Dartifact="com.rudderstack.sdk.java.analytics:analytics:${version}" \
+  -Dtransitive=true \
+  -DremoteRepositories="central::default::${central_url}" \
+  org.apache.maven.plugins:maven-dependency-plugin:3.11.0:get
+
+echo "Maven Central release ${version} is public and consumable from a clean cache."

--- a/scripts/verify-published-poms.sh
+++ b/scripts/verify-published-poms.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+version="${1:?usage: verify-published-poms.sh <version>}"
+
+if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Invalid release version: $version" >&2
+  exit 1
+fi
+
+for artifact in analytics-parent analytics-core analytics analytics-sample; do
+  case "$artifact" in
+    analytics-parent)
+      pom=".flattened-pom.xml"
+      ;;
+    *)
+      pom="${artifact}/.flattened-pom.xml"
+      ;;
+  esac
+
+  test -s "$pom"
+
+  if grep -Eq '<version>[[:space:]]*\$\{revision\}[[:space:]]*</version>' "$pom"; then
+    echo "Unresolved project or parent version in $pom" >&2
+    exit 1
+  fi
+
+  grep -Fq "<version>${version}</version>" "$pom"
+done
+
+for element in name description url licenses developers scm; do
+  grep -Fq "<$element>" .flattened-pom.xml
+done
+
+echo "Published POMs contain concrete versions and required metadata for ${version}."

--- a/scripts/verify-release-artifacts.sh
+++ b/scripts/verify-release-artifacts.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+version="${1:?usage: verify-release-artifacts.sh <version>}"
+
+scripts/verify-published-poms.sh "$version"
+
+for artifact in analytics-parent analytics-core analytics analytics-sample; do
+  case "$artifact" in
+    analytics-parent)
+      pom=".flattened-pom.xml"
+      signature="target/${artifact}-${version}.pom.asc"
+      ;;
+    *)
+      pom="${artifact}/.flattened-pom.xml"
+      signature="${artifact}/target/${artifact}-${version}.pom.asc"
+      ;;
+  esac
+
+  test -s "$signature"
+  gpg --batch --verify "$signature" "$pom"
+done
+
+for artifact in analytics-core analytics analytics-sample; do
+  directory="$artifact/target"
+
+  for classifier in "" -sources -javadoc; do
+    archive="$directory/${artifact}-${version}${classifier}.jar"
+    test -s "$archive"
+    test -s "$archive.asc"
+    gpg --batch --verify "$archive.asc" "$archive"
+  done
+done
+
+sample_archive="analytics-sample/target/analytics-sample-${version}-jar-with-dependencies.jar"
+test -s "$sample_archive"
+test -s "$sample_archive.asc"
+gpg --batch --verify "$sample_archive.asc" "$sample_archive"
+
+echo "Release POMs, archives, and OpenPGP signatures are valid for ${version}."


### PR DESCRIPTION
## Summary

- publish each Release Please GitHub release from its exact `vX.Y.Z` tag
- generate concrete consumer POMs and validate all signed release artifacts
- auto-publish with Sonatype's Central Publishing Maven Plugin and wait for `PUBLISHED`
- verify public, transitive resolution from a clean Maven cache
- notify the release Slack channel on Maven publication success or failure
- document release, recovery, and credential-rotation procedures
- restore the Java build workflow by replacing retired and enterprise-blocked actions

## Safety

- the PR does not publish a Maven release
- the workflow only accepts release tags that match the POM version and belong to `master`
- reruns skip immutable versions that are already public
- the `maven-central` Environment permits only `v*` tags
- all external GitHub Actions are pinned to commit SHAs
- GitHub token permissions are defined separately for each job

## Verification

- `mvn --batch-mode --no-transfer-progress clean verify`
- 326 tests passed locally and in GitHub Actions
- published POM checks passed for all four modules
- full `release` profile created sources, Javadocs, and detached signatures
- all generated signatures verified with an isolated test key
- Maven Central public smoke test passed against `3.1.4`
- SonarCloud analysis and quality gate passed
- `actionlint .github/workflows/*.yml`
- `bash -n scripts/*.sh`
- `git diff --check`
- GitHub security, policy, Snyk, CodeQL, PMD, and Checkstyle checks passed

## Sonar resolution

The repository pinned Sonar Maven scanner `3.7.0.1746`, which did not read the `SONAR_TOKEN` environment variable. The scanner now uses `5.7.0.6970`. The inherited organization secret authenticates successfully, analysis uploads successfully, and the Sonar quality gate passes. The stale repository-level token override remains removed.

## Tracking

- [SDK-5337](https://linear.app/rudderstack/issue/SDK-5337/automate-java-sdk-publishing-to-maven-central)
- [Java SDK release process](https://app.notion.com/p/7d34a610c85e4999b9404ca166911d3e)
